### PR TITLE
Enhance card fetching and data handling features

### DIFF
--- a/CardCrawler.Cardmarket/CardData.cs
+++ b/CardCrawler.Cardmarket/CardData.cs
@@ -1,14 +1,16 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Web;
 
 namespace CardCrawler.Cardmarket
 {
     public class CardData(string name)
     {
-        public string Name { get; set; } = name;
-        public string UrlName { get; set; } = Utilities.UrlEncodeCardName(Utilities.CleanCardName(name));
+        public string Name { get; } = name;
+
+        public string UrlName { get; set; } = string.Empty;
 
         public string ImageUrl { get; set; } = string.Empty;
         public Stream ImageStream { get; set; } = null;

--- a/CardCrawler.Cardmarket/Utilities.cs
+++ b/CardCrawler.Cardmarket/Utilities.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.Win32;
 using System;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace CardCrawler.Cardmarket
 {
-    public static class Utilities
+    public static partial class Utilities
     {
         private static readonly Regex CleanCardNameRegex = new(@"^\d+\s+([^\(]+)", RegexOptions.Compiled);
         private static readonly Regex RemovePrefixesRegex = new(@"^\d+\s*[xX]?\s*", RegexOptions.Compiled);
@@ -15,73 +16,19 @@ namespace CardCrawler.Cardmarket
         private static readonly Regex RemoveSlashesRegex = new(@"\s*\/", RegexOptions.Compiled);
         private static readonly Regex UrlEncodeRegex = new(@"[^a-zA-Z0-9\-]", RegexOptions.Compiled);
 
+        [GeneratedRegex(@"^(?:\d*[x|X]*\s+)(?<name>.*?)(?:\s\(.*)?$", RegexOptions.Singleline)]
+        private static partial Regex CardNameExtractionRegex();
+
         public static string CleanCardName(string cardName)
         {
-            if (string.IsNullOrWhiteSpace(cardName))
-            {
-                return string.Empty;
-            }
-
-            // Match and clean the card name
-            Match match = CleanCardNameRegex.Match(cardName);
-            if (match.Success)
-            {
-                string cleanedCardName = match.Groups[1].Value.Trim()
-                    .Replace("//", " ")
-                    .Replace(" / ", " ")
-                    .Replace("/", " ");
-                return cleanedCardName;
-            }
-
-            // Apply regex replacements for other cases
-            string cleanedEntry = RemovePrefixesRegex.Replace(cardName, "");
-            cleanedEntry = RemoveParenthesesAndSuffixRegex.Replace(cleanedEntry, "");
-            cleanedEntry = RemoveParenthesesRegex.Replace(cleanedEntry, "");
-            cleanedEntry = RemoveAsteriskSuffixRegex.Replace(cleanedEntry, "");
-            cleanedEntry = RemoveSlashesRegex.Replace(cleanedEntry, "");
-            return cleanedEntry.Trim();
+            return CardNameExtractionRegex().Match(cardName).Groups["name"].Value;
         }
 
         public static string UrlEncodeCardName(string cardName)
         {
-            if (string.IsNullOrWhiteSpace(cardName))
-            {
-                return string.Empty;
-            }
-
-            string formattedName = cardName.Trim();
-            formattedName = Regex.Replace(formattedName, @"^\d+\s*", ""); // Remove leading numbers
-            formattedName = Regex.Replace(formattedName, @"-", "");   // Remove hyphens
-            formattedName = Regex.Replace(formattedName, @"\s+", "-");   // Replace spaces with hyphens
-            formattedName = Regex.Replace(formattedName, @"'+", "");    // Remove apostrophes
-            formattedName = formattedName.Replace("\\P{L}+", "");  // Remove invalid characters
-            return formattedName;
-        }
-
-        public static string GetEdgePath()
-        {
-            const string regKey = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\msedge.exe";
-            string path = Registry.GetValue(regKey, "", null) as string;
-            if (!string.IsNullOrEmpty(path) && File.Exists(path))
-            {
-                return path;
-            }
-
-            string[] candidates =  [      
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
-                         "Microsoft\\Edge\\Application\\msedge.exe"),                       
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), 
-                "Microsoft\\Edge\\Application\\msedge.exe")    
-                ];
-            foreach (string p in candidates)
-            {
-                if (File.Exists(p))
-                {
-                    return p;
-                }
-            }
-
-            return "msedge.exe";
+            cardName = string.Join(" ", Regex.Matches(cardName, @"\w+").Select(m => m.Value));  // Remove invalid characters
+            cardName = Regex.Replace(cardName, @"\s", "-");   // Remove hyphens
+            return cardName;
         }
 
     }

--- a/CardCrawler/Deck - Copy (2).txt
+++ b/CardCrawler/Deck - Copy (2).txt
@@ -8,4 +8,4 @@
 1 Jori En, Ruin Diver (OGW) 155
 1 Iron-Fist Pulverizer (OTJ) 131 *F*
 1 Tormod's Crypt (DMR) 235
-
+1 Revitalizing Repast // Old-Growth Grove (MH3) 256

--- a/CardCrawler/Deck.txt
+++ b/CardCrawler/Deck.txt
@@ -1,1 +1,90 @@
-1 Clavileño, First of the Blessed
+1 Xavier Sal, Infested Captain (LCC) 14
+1 Agent Frank Horrigan (PIP) 89
+1 Anoint with Affliction (ONE) 81
+1 Basking Broodscale (MH3) 145
+1 Bilious Skulldweller (ONE) 83
+1 Binding the Old Gods (DSC) 213
+1 Blight Mamba (PLST) SOM-112
+1 Blightbelly Rat (ONE) 289
+1 Blighted Agent (NPH) 29
+1 Bloated Contaminator (ONE) 159
+1 Bloodroot Apothecary (BLC) 27
+1 Bojuka Bog (TDC) 341
+1 Bring the Ending (ONE) 44
+1 Cankerbloom (ONE) 294
+1 Command Tower (TDC) 107
+1 Corrupted Conscience (MBS) 22
+1 Corrupted Resolve (NPH) 32
+1 Counterspell (CMM) 630
+1 Cultivate (TDC) 253
+1 Darkwater Catacombs (TDC) 355
+1 Dimir Aqueduct (DSC) 270
+1 Dimir Signet (CLU) 221
+1 Dreamroot Cascade (TDC) 358
+1 Evolution Sage (LCC) 240
+1 Evolution Witness (MH3) 151
+1 Experimental Augury (ONE) 49
+1 Ezuri, Stalker of Spheres (ONE) 317
+1 Flooded Grove (TDC) 364
+1 Foreboding Landscape (TDC) 365
+5 Forest (LCI) 402
+1 Golgari Rot Farm (TDC) 368
+1 Golgari Signet (DSC) 246
+1 Hand of the Praetors (SOM) 66
+1 Hinterland Harbor (TDC) 371
+1 Ichor Rats (SOM) 67
+1 Infectious Bite (ONE) 172
+1 Infectious Inquiry (ONE) 97
+1 Intruder Alarm (8ED) 86
+4 Island (TDM) 279
+1 Kiora's Follower (LCC) 273
+1 Llanowar Elves (DOM) 168
+1 Llanowar Wastes (TDC) 376
+1 Mimic Vat (NCC) 372
+1 Necrogen Communion (ONE) 99
+1 Negate (FDN) 710 *F*
+1 Noxious Assault (ONE) 176
+1 Opulent Palace (TDM) 264
+1 Path of Ancestry (TDC) 382
+1 Pestilent Syphoner (ONE) 103
+1 Phyresis (MBS) 49
+1 Phyresis Outbreak (ONC) 50
+1 Plague Stinger (SOM) 75
+1 Poison Dart Frog (LCI) 207
+1 Prologue to Phyresis (ONE) 65
+1 Reject Imperfection (ONE) 67
+1 Revitalizing Repast // Old-Growth Grove (MH3) 256
+1 Roalesk, Apex Hybrid (NCC) 349
+1 Rogue's Passage (FDN) 264
+1 Sakura-Tribe Elder (TDC) 266
+1 Serum Snare (ONE) 68
+1 Simic Growth Chamber (DSC) 298
+1 Simic Signet (DSC) 252
+1 Sol Ring (TDC) 106
+1 Staff of Compleation (TDC) 326
+1 Sunken Hollow (TDC) 398
+4 Swamp (TDM) 281
+1 Tainted Observer (ONE) 217
+1 Tainted Wood (DSC) 305
+1 Talisman of Curiosity (MKC) 241
+1 Talisman of Dominance (MKC) 242
+1 Talisman of Resilience (DSC) 255
+1 Temple of Deceit (FDN) 697
+1 Temple of Malady (TDC) 403
+1 Temple of Mystery (TDC) 404
+1 Terramorphic Expanse (TDC) 408
+1 Tezzeret's Gambit (M3C) 194
+1 Thrummingbird (ONE) 288
+1 Tyrranax Rex (ONE) 189
+1 Tyvar, Jubilant Brawler (ONE) 218
+1 Unnatural Restoration (ONE) 191
+1 Urborg Elf (APC) 90
+1 Venerated Rotpriest (PONE) 192p
+1 Venser, Corpse Puppet (ONE) 219
+1 Viridescent Bog (DSC) 324
+1 Viridian Corrupter (ONC) 113
+1 Voidwing Hybrid (ONE) 221
+1 Vraska's Fall (ONE) 116
+1 Whispersilk Cloak (DSC) 257
+1 Woodland Cemetery (TDC) 412
+1 Yavimaya Coast (TDC) 413

--- a/CardCrawler/Properties/launchSettings.json
+++ b/CardCrawler/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "CardCrawler": {
       "commandName": "Project",
-      "commandLineArgs": "Deck.txt Prices.txt --no-basics --budget=2.5 --exclude=exclude.txt"
+      "commandLineArgs": "Deck.txt Prices.txt --no-basics --budget=25 --exclude=exclude.txt"
     }
   }
 }

--- a/CardCrawler/exclude.txt
+++ b/CardCrawler/exclude.txt
@@ -1,3 +1,5 @@
+Xavier Sal, Infested Captain
+
 Abraded Bluffs
 Alpine Meadow
 Arcane Sanctum


### PR DESCRIPTION
- Added `retries` parameter to `GetPageContent` in `Edge.cs` for handling 429 status codes with retry logic.
- Made `Name` property read-only in `CardData.cs` and initialized `UrlName` to an empty string.
- Updated `GetCardData` in `Reader.cs` to use cleaned card names for URL encoding and improved data retrieval.
- Refactored `CleanCardName` in `Utilities.cs` to utilize generated regex for better name extraction.
- Improved `UrlEncodeCardName` to effectively remove invalid characters and replace spaces with hyphens.
- Changed collections for basic lands and excluded cards in `Program.cs` from `HashSet` to `List` for easier management.
- Enhanced console output formatting for clarity regarding excluded cards and basic lands.
- Adjusted CSV output format to change field order and indicate budget status.