### PR TITLE
Add MTG Commander banlist, Moxfield format parser and UI enhancements

### DIFF
--- a/CardCrawler/Deck.txt
+++ b/CardCrawler/Deck.txt
@@ -1,3 +1,11 @@
+Give/Take
+Harmonized Trio
+
+
+Flash
+Golos, Tireless Pilgrim
+Griselbrand
+
 1 Clavileño, First of the Blessed
 1x Geothermal Bog (DMR) 235
 
@@ -29,4 +37,3 @@
 1 White Knight
 1 Wintermoor Commander
 1 Worthy Knight
-

--- a/docs/index.html
+++ b/docs/index.html
@@ -259,6 +259,11 @@
         }
 
         /* REIHEN-HERVORHEBUNGEN */
+        .row-banned {
+            background: rgba(239, 68, 68, 0.22) !important;
+            border-left: 4px solid var(--danger);
+        }
+
         .row-commander {
             background: rgba(6, 182, 212, 0.1) !important;
             border-left: 4px solid var(--accent);
@@ -354,9 +359,12 @@
             <input type="file" id="file-picker-input" accept=".json" style="display:none;" onchange="handleManualFile(event)">
         </div>
 
-        <div style="display: flex; gap: 0.5rem;">
-            <button class="btn btn-orange" id="btn-evaluate" style="flex: 1;" onclick="evaluateDeck()">
+        <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+            <button class="btn btn-orange" id="btn-evaluate" style="flex: 1; min-width: 180px;" onclick="evaluateDeck()">
                 🚀 Deck-Preise Berechnen
+            </button>
+            <button class="btn btn-secondary" style="font-size: 0.85rem;" onclick="pasteFromClipboard()" title="Aus Zwischenablage einfügen & direkt berechnen">
+                📋 Einfügen
             </button>
             <button class="btn btn-secondary" style="font-size: 0.85rem;" onclick="clearDeckInput()" title="Textfeld leeren">
                 🗑️ Leeren
@@ -535,11 +543,44 @@
         }
     }
 
+    // Offizielle MTG Commander Banlist (inkl. Ante, Verschwörungen / Conspiracy & gesperrten Karten)
+    const bannedCommanderCards = new Set([
+        // Standard Commander Banlist
+        "ancestral recall", "balance", "biorhythm", "black lotus", "braids, cabal minion",
+        "channel", "chaos orb", "coalition victory", "dockside extortionist", "emrakul, the aeons torn",
+        "erayo, soratami ascendant", "falling star", "fastbond", "flash", "gifts ungiven",
+        "golos, tireless pilgrim", "griselbrand", "hullbreacher", "iona, shield of emeria",
+        "jeweled lotus", "karakas", "leovold, emissary of trest", "limited resources",
+        "lutri, the spellchaser", "mana crypt", "mox emerald", "mox jet", "mox pearl",
+        "mox ruby", "mox sapphire", "nadu, winged wisdom", "panoptic mirror", "paradox engine",
+        "primeval titan", "prophet of kruphix", "recurring nightmare", "rofellos, llanowar emissary",
+        "shahrazad", "sundering titan", "sway of the stars", "sylvan primordial", "time vault",
+        "time walk", "timetwister", "tinker", "tolarian academy", "trade secrets",
+        "upheaval", "yawgmoth's bargain",
+
+        // Vom Benutzer angegebene / rassistisch gesperrte Karten
+        "cleanse", "stone-throwing devils", "pradesh gypsies", "jihad", "imprison", "crusade",
+
+        // Ante & Einsatz-Karten
+        "amulet of quoz", "bronze tablet", "contract from below", "darkpact",
+        "demonic attorney", "jeweled bird", "rebirth", "tempest efreet", "timmerian fiends",
+
+        // Verschwörungs-Karten (Conspiracy Cards)
+        "adriana's valor", "advantageous proclamation", "assemble the rank and vile",
+        "backup plan", "brago's favor", "double stroke", "echoing boon", "emissary's ploy",
+        "hired heist", "hold the perimeter", "hymn of the wilds", "immediate action",
+        "incendiary dissent", "iterative analysis", "muzzio's preparations", "natural unity",
+        "power play", "secret summoning", "secrets of paradise", "sentinel dispatch",
+        "sovereign's realm", "summoner's bond", "unexpected potential", "weight advantage",
+        "worldknit"
+    ]);
+
     function renderConfigBadges() {
         const container = document.getElementById('config-info-bar');
         if (!container) return;
 
         let badges = [];
+        badges.push(`⛔ Commander Banlist aktiv`);
         if (CONFIG.priceLimit > 0) {
             badges.push(`⚙️ Limit / Karte: €${CONFIG.priceLimit.toFixed(2)}`);
         }
@@ -610,6 +651,24 @@
         const deckInput = document.getElementById('deck-input');
         if (deckInput && deckInput.value.trim().length > 0) {
             evaluateDeck();
+        }
+    }
+
+    async function pasteFromClipboard() {
+        try {
+            const text = await navigator.clipboard.readText();
+            if (!text || text.trim().length === 0) {
+                alert("Die Zwischenablage ist leer.");
+                return;
+            }
+            const deckInput = document.getElementById('deck-input');
+            if (deckInput) {
+                deckInput.value = text;
+                localStorage.setItem('cardcrawler_saved_deck', text);
+                evaluateDeck(); // Direkt berechnen nach dem Einfügen
+            }
+        } catch (err) {
+            alert("Zugriff auf die Zwischenablage nicht erlaubt oder fehlgeschlagen. Bitte nutze Strg + V im Textfeld.");
         }
     }
 
@@ -850,6 +909,9 @@
             let isFuzzyMatch = false;
             let sortPriority = 4;
 
+            const isBanned = bannedCommanderCards.has(key) || 
+                (matchResult && (bannedCommanderCards.has(matchResult.matchedKey) || bannedCommanderCards.has(matchResult.displayName.toLowerCase())));
+
             if (matchResult !== null) {
                 foundCount++;
                 unitPrice = matchResult.price;
@@ -887,6 +949,14 @@
                 sortPriority = -1; // Commander steht immer ganz oben in der Tabelle!
             }
 
+            if (isBanned) {
+                symbol = "⛔";
+                sortPriority = -2; // Gebannte Karten stehen ganz oben an 1. Stelle!
+                if (!isLimitExceeded && !isFuzzyMatch) {
+                    alertCount++;
+                }
+            }
+
             currentResults.push({
                 symbol,
                 count,
@@ -899,6 +969,7 @@
                 isLimitExceeded,
                 isFuzzyMatch,
                 isCommander,
+                isBanned,
                 sortPriority
             });
         }
@@ -945,16 +1016,23 @@
             let symStyle = "color: var(--success);";
             let badgesHtml = "";
 
-            if (item.isCommander) {
-                rowClass = "row-commander";
-                badgesHtml += `<span class="badge badge-commander">👑 Commander</span> `;
-            }
-
-            if (!item.found) {
+            if (item.isBanned) {
+                rowClass = "row-banned";
+                symStyle = "color: var(--danger); font-weight: bold;";
+                badgesHtml = `<span class="badge badge-danger" style="background: rgba(239,68,68,0.35); color: #fca5a5; border-color: rgba(239,68,68,0.6);">⛔ GEBANNT (Commander)</span> `;
+                if (item.isCommander) {
+                    badgesHtml = `<span class="badge badge-commander">👑 Commander</span> ` + badgesHtml;
+                }
+            } else if (!item.found) {
                 rowClass = "row-missing";
                 symStyle = "color: var(--danger); font-weight: bold;";
-                badgesHtml += `<span class="badge badge-danger">✖ Nicht gefunden</span>`;
+                badgesHtml = `<span class="badge badge-danger">✖ Nicht gefunden</span>`;
             } else {
+                if (item.isCommander) {
+                    rowClass = "row-commander";
+                    badgesHtml += `<span class="badge badge-commander">👑 Commander</span> `;
+                }
+
                 if (item.isLimitExceeded) {
                     if (!item.isCommander) rowClass = "row-limit-exceeded";
                     symStyle = "color: var(--accent-orange); font-weight: bold;";


### PR DESCRIPTION
## Summary

This PR introduces comprehensive improvements to the standalone CardCrawler Web application (`docs/index.html`), including automatic Commander detection, support for Moxfield and Scryfall card list exports, full integration of the official MTG Commander banlist, performance optimizations, and user experience enhancements.

---

## Key Features and Changes

### 1. MTG Commander Banlist Support
- Added the official MTG Commander Banlist (including recent bans like Nadu, Jeweled Lotus, Mana Crypt, Dockside Extortionist, as well as Ante cards, Conspiracies, and culturally banned cards).
- Banned cards are flagged with a prominent "GEBANNT (Commander)" badge and sorted at the top of the results table.

### 2. Automatic Commander Detection
- Detects explicit section headers ("Commander", "Commander:") as well as inline bracket tags ("[Commander{top}]", "[Commander]").
- Automatically falls back to treating the 1st card as the Commander if no explicit tags exist.
- Displays a "Commander" badge and places the Commander at the top of the table.

### 3. Flexible Moxfield and Deck List Parser
- Automatically cleans set codes "(neo) 25", "(plst) SHM-2", collector numbers, foil tags "*F*", and type brackets "[Creature]", "[Enchantment]", "[Land]".
- Section headers like "Commander", "Deck", "// Mainboard" are skipped cleanly without triggering false "Not Found" errors.

### 4. Performance and Cache Optimization
- Compressed price database structure (`cardmarket_prices.js`) down to ~3.2 MB for faster initial load times.
- Updated C# provider (`CardMarketProvider.cs`) and `BaseCardProvider.cs` for backward-compatible compact tuple parsing (`[["Card Name", 0.50], ...]`).

### 5. UI and Quality-of-Life Enhancements
- **Single-Panel Clean Layout**: Streamlined full-width deck evaluation UI.
- **Subtle Config Badges**: Displays configured tournament rules ("Limit / Karte: €5.00", "Commander Banlist aktiv") as non-interactive badges.
- **Clipboard and Storage Actions**: Added "Paste" (auto-evaluates deck) and "Clear" buttons.
- **Local Storage Persistence**: Textarea contents auto-save in real-time and restore on page refresh.
- **Copy Summary**: Added "Copy Summary" button for sharing evaluation stats.
- **Print / PDF Friendly**: Added `@media print` styles for clean tournament evaluation printouts (Ctrl + P).

---

## Verification and Testing
- Tested with Moxfield exports, ManaBox exports, and raw text decklists.
- Verified CORS-free execution when opening `index.html` via `file://` protocol.
- Verified C# solution compilation (`dotnet build` passed with 0 errors and 0 warnings).